### PR TITLE
Updating jcabi-github version to 0.22 (latest release)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1012,7 +1012,7 @@
                 -->
                 <groupId>com.jcabi</groupId>
                 <artifactId>jcabi-github</artifactId>
-                <version>0.17</version>
+                <version>0.22</version>
             </dependency>
             <dependency>
                 <!--


### PR DESCRIPTION
For task #25 , updating POM.xml to refer to `jcabi-github` 0.22.