### PR TITLE
Upgrade maven-compiler-plugin to v3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1541,7 +1541,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.3</version>
                     <configuration>
                         <source>1.6</source>
                         <target>1.6</target>


### PR DESCRIPTION
The old version (3.1) was released 03-Apr-2013. The new version was released 23-Mar-2015.
See http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.apache.maven.plugins%22%20AND%20a%3A%22maven-compiler-plugin%22