### PR TITLE
prevent Maven 3.5 build warnings related to reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,139 +285,6 @@
                         <artifactId>maven-site-plugin</artifactId>
                         <configuration>
                             <generateSitemap>true</generateSitemap>
-                            <reportPlugins>
-                                <plugin>
-                                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                                    <version>2.7</version>
-                                    <configuration>
-                                        <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
-                                        <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                                    </configuration>
-                                    <reportSets>
-                                        <reportSet>
-                                            <reports>
-                                                <report>cim</report>
-                                                <report>dependencies</report>
-                                                <report>index</report>
-                                                <report>issue-tracking</report>
-                                                <report>license</report>
-                                                <report>mailing-list</report>
-                                                <report>plugins</report>
-                                                <report>project-team</report>
-                                                <report>scm</report>
-                                                <report>summary</report>
-                                            </reports>
-                                        </reportSet>
-                                    </reportSets>
-                                </plugin>
-                                <plugin>
-                                    <artifactId>maven-jxr-plugin</artifactId>
-                                    <version>2.4</version>
-                                    <configuration>
-                                        <aggregate>true</aggregate>
-                                    </configuration>
-                                </plugin>
-                                <plugin>
-                                    <artifactId>maven-surefire-report-plugin</artifactId>
-                                    <version>2.17</version>
-                                    <reportSets>
-                                        <reportSet>
-                                            <reports>
-                                                <report>report-only</report>
-                                            </reports>
-                                        </reportSet>
-                                    </reportSets>
-                                </plugin>
-                                <plugin>
-                                    <!--
-                                    Shows reports about recent versions of plugins and deps.
-                                    @see http://mojo.codehaus.org/versions-maven-plugin/
-                                    -->
-                                    <groupId>org.codehaus.mojo</groupId>
-                                    <artifactId>versions-maven-plugin</artifactId>
-                                    <version>2.2</version>
-                                    <reportSets>
-                                        <reportSet>
-                                            <reports>
-                                                <report>dependency-updates-report</report>
-                                                <report>plugin-updates-report</report>
-                                            </reports>
-                                        </reportSet>
-                                    </reportSets>
-                                </plugin>
-                                <plugin>
-                                    <!--
-                                    API documentation builder. It will produce documentation
-                                    which is then to be used in site:site. It will be
-                                    located at target/site/apidocs.
-                                    -->
-                                    <artifactId>maven-javadoc-plugin</artifactId>
-                                    <configuration>
-                                        <failOnError>true</failOnError>
-                                        <quiet>true</quiet>
-                                        <links>
-                                            <link>http://download.oracle.com/javaee/6/api/</link>
-                                            <link>http://sonatype.github.com/sonatype-aether/apidocs/</link>
-                                            <link>http://hamcrest.org/JavaHamcrest/javadoc/1.3/</link>
-                                            <link>http://docs.mockito.googlecode.com/hg/latest/</link>
-                                            <link>http://www.h2database.com/javadoc/</link>
-                                            <link>http://jolbox.com/bonecp/downloads/site/apidocs/</link>
-                                        </links>
-                                        <detectLinks>true</detectLinks>
-                                        <additionalparam>${javadoc.opts}</additionalparam>
-                                        <tags>
-                                            <!--
-                                            Here we instruct plugin to use custom tag
-                                            @link http://maven.apache.org/plugins/maven-javadoc-plugin/examples/tag-configuration.html
-                                            -->
-                                            <tag>
-                                                <name>todo</name>
-                                                <placement>a</placement>
-                                                <head>To do:</head>
-                                            </tag>
-                                            <tag>
-                                                <name>checkstyle</name>
-                                                <placement>a</placement>
-                                                <head>Suppressed Checkstyle violations:</head>
-                                            </tag>
-                                        </tags>
-                                    </configuration>
-                                    <reportSets>
-                                        <reportSet>
-                                            <id>jcabi-versioned-html</id>
-                                            <reports>
-                                                <report>javadoc</report>
-                                            </reports>
-                                            <configuration>
-                                                <windowtitle>${project.name} ${project.version} API</windowtitle>
-                                                <doctitle>${project.name} ${project.version} API</doctitle>
-                                                <sourcepath>src/main/java</sourcepath>
-                                                <destDir>apidocs-${project.version}</destDir>
-                                            </configuration>
-                                        </reportSet>
-                                        <reportSet>
-                                            <id>jcabi-versioned-test</id>
-                                            <reports>
-                                                <report>test-javadoc</report>
-                                            </reports>
-                                            <configuration>
-                                                <testWindowtitle>${project.name} ${project.version} Mock API</testWindowtitle>
-                                                <testDoctitle>${project.name} ${project.version} Mock API</testDoctitle>
-                                                <sourcepath>src/mock/java</sourcepath>
-                                                <destDir>testapidocs-${project.version}</destDir>
-                                            </configuration>
-                                        </reportSet>
-                                    </reportSets>
-                                </plugin>
-                                <plugin>
-                                    <groupId>org.jacoco</groupId>
-                                    <artifactId>jacoco-maven-plugin</artifactId>
-                                </plugin>
-                                <plugin>
-                                    <artifactId>maven-plugin-plugin</artifactId>
-                                    <version>3.3</version>
-                                </plugin>
-                            </reportPlugins>
                         </configuration>
                         <executions>
                             <execution>
@@ -430,6 +297,141 @@
                     </plugin>
                 </plugins>
             </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-project-info-reports-plugin</artifactId>
+                        <version>2.7</version>
+                        <configuration>
+                            <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+                            <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                        </configuration>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>cim</report>
+                                    <report>dependencies</report>
+                                    <report>index</report>
+                                    <report>issue-tracking</report>
+                                    <report>license</report>
+                                    <report>mailing-list</report>
+                                    <report>plugins</report>
+                                    <report>project-team</report>
+                                    <report>scm</report>
+                                    <report>summary</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-jxr-plugin</artifactId>
+                        <version>2.4</version>
+                        <configuration>
+                            <aggregate>true</aggregate>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-report-plugin</artifactId>
+                        <version>2.17</version>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>report-only</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                    <plugin>
+                        <!--
+                        Shows reports about recent versions of plugins and deps.
+                        @see http://mojo.codehaus.org/versions-maven-plugin/
+                        -->
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>versions-maven-plugin</artifactId>
+                        <version>2.2</version>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>dependency-updates-report</report>
+                                    <report>plugin-updates-report</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                    <plugin>
+                        <!--
+                        API documentation builder. It will produce documentation
+                        which is then to be used in site:site. It will be
+                        located at target/site/apidocs.
+                        -->
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <failOnError>true</failOnError>
+                            <quiet>true</quiet>
+                            <links>
+                                <link>http://download.oracle.com/javaee/6/api/</link>
+                                <link>http://sonatype.github.com/sonatype-aether/apidocs/</link>
+                                <link>http://hamcrest.org/JavaHamcrest/javadoc/1.3/</link>
+                                <link>http://docs.mockito.googlecode.com/hg/latest/</link>
+                                <link>http://www.h2database.com/javadoc/</link>
+                                <link>http://jolbox.com/bonecp/downloads/site/apidocs/</link>
+                            </links>
+                            <detectLinks>true</detectLinks>
+                            <additionalparam>${javadoc.opts}</additionalparam>
+                            <tags>
+                                <!--
+                                Here we instruct plugin to use custom tag
+                                @link http://maven.apache.org/plugins/maven-javadoc-plugin/examples/tag-configuration.html
+                                -->
+                                <tag>
+                                    <name>todo</name>
+                                    <placement>a</placement>
+                                    <head>To do:</head>
+                                </tag>
+                                <tag>
+                                    <name>checkstyle</name>
+                                    <placement>a</placement>
+                                    <head>Suppressed Checkstyle violations:</head>
+                                </tag>
+                            </tags>
+                        </configuration>
+                        <reportSets>
+                            <reportSet>
+                                <id>jcabi-versioned-html</id>
+                                <reports>
+                                    <report>javadoc</report>
+                                </reports>
+                                <configuration>
+                                    <windowtitle>${project.name} ${project.version} API</windowtitle>
+                                    <doctitle>${project.name} ${project.version} API</doctitle>
+                                    <sourcepath>src/main/java</sourcepath>
+                                    <destDir>apidocs-${project.version}</destDir>
+                                </configuration>
+                            </reportSet>
+                            <reportSet>
+                                <id>jcabi-versioned-test</id>
+                                <reports>
+                                    <report>test-javadoc</report>
+                                </reports>
+                                <configuration>
+                                    <testWindowtitle>${project.name} ${project.version} Mock API</testWindowtitle>
+                                    <testDoctitle>${project.name} ${project.version} Mock API</testDoctitle>
+                                    <sourcepath>src/mock/java</sourcepath>
+                                    <destDir>testapidocs-${project.version}</destDir>
+                                </configuration>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-plugin-plugin</artifactId>
+                        <version>3.3</version>
+                    </plugin>
+                </plugins>
+            </reporting>
         </profile>
         <profile>
             <!--
@@ -1654,15 +1656,6 @@
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.4</version>
-                    <configuration>
-                        <reportPlugins>
-                            <!--
-                            Section is intentionally empty. Full list of plugins
-                            is configured in "CI" profile. We don't need all them
-                            during development, that's why they are not here.
-                            -->
-                        </reportPlugins>
-                    </configuration>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.doxia</groupId>


### PR DESCRIPTION
(plugin definitions are moved from 'maven-site-plugin/reportPlugins' section into newly created 'reporting' section)

`Solves issue: `#69 **_(warning about maven-site-plugin)_**

`Related links:`
- https://issues.apache.org/jira/browse/MNG-6189 **_WARN if maven-site-plugin configuration contains reportPlugins element_**
- https://maven.apache.org/guides/mini/guide-configuring-plugins.html#Configuring_Reporting_Plugins


