### PR TITLE
prevent build warnings related to 'prerequisites' usage; introduce maven version borders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,9 +96,6 @@
             <url>http://parent.jcabi.com/</url>
         </site>
     </distributionManagement>
-    <prerequisites>
-        <maven>3.0.4</maven>
-    </prerequisites>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -1455,7 +1452,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.1</version>
+                                    <version>[3.2.5,)</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
**Maven build generates warnings:** 

> [WARNING] The project com.jcabi:parent:pom:1.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes
>  you should use the maven-enforcer-plugin. See `https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html` 

**_Notes:_**
* 'prerequisites' tag (with declared maven version) is removed
* required maven version lower border is set to **3.2.5** (last java 6 compatible version); upper border is left open