### PR TITLE
Always generate the source attachment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,9 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
             <executions>
               <execution>
                 <id>jcabi-sources</id>
+                <configuration>
+                  <forceCreation>true</forceCreation>
+                </configuration>
                 <goals>
                   <goal>jar</goal>
                 </goals>


### PR DESCRIPTION
By default, maven-source-plugin will only generate the source jar if there are sources. However, there are instances where there are no sources for an artifact (such as if it simply depends on other artifacts). In those cases, a source jar should still be generated - primarily because Maven Central / Sonatype requires a source jar.

See https://maven.apache.org/plugins/maven-source-plugin/jar-mojo.html#forceCreation

Many thanks for your contribution, we truly appreciate it. We will appreciate it even more, if you make sure that you can say "YES" to each point in this short checklist:

  - You made a small amount of changes (less than 100 lines, less than 10 files)
  - You made changes related to only one bug (create separate PRs for separate problems)
  - You are ready to defend your changes (there will be a code review)
  - You don't touch what you don't understand
  - You ran the build locally and it passed

This article will help you understand what we are looking for: http://www.yegor256.com/2015/02/09/serious-code-reviewer.html

Thank you for your contribution!
