### PR TITLE
For #88. Fix xcop on Windows.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,10 +243,10 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     </profile>
     <profile>
       <!--
-      Xdoc is a static validator of XML formatting.
-      @see https://github.com/yegor256/xdoc/
+      Xcop is a static validator of XML formatting.
+      @see https://github.com/yegor256/xcop/
       -->
-      <id>xdoc</id>
+      <id>xcop</id>
       <activation>
         <file>
           <exists>${basedir}/LICENSE.txt</exists>

--- a/pom.xml
+++ b/pom.xml
@@ -283,9 +283,10 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
                           <equals arg1="${os.windows}" arg2="true"/>
                           <then>
                             <exec executable="cmd" failonerror="true">
+                              <arg line="/c xcop"/>
                               <arg value="--license"/>
                               <arg value="LICENSE.txt"/>
-                              <arg line="/c xcop ${converted}"/>
+                              <arg line="${converted}"/>
                             </exec>
                           </then>
                           <else>


### PR DESCRIPTION
For #88
- Now xcop runs with the `--license` option. 