### PR TITLE
Fix errors during javadoc generation in site goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1751,12 +1751,12 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
+          <version>3.9.1</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.doxia</groupId>
               <artifactId>doxia-module-markdown</artifactId>
-              <version>1.6</version>
+              <version>1.9.1</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
This fixes this bug I uncovered when bumping cactoos to jcabi-parent 0.50.0: https://travis-ci.org/github/yegor256/cactoos/builds/705136790