### PR TITLE
Moved qulice configuration to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,12 +230,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
                 <goals>
                   <goal>check</goal>
                 </goals>
-                <configuration>
-                  <license>file:${basedir}/LICENSE.txt</license>
-                  <excludes>
-                    <exclude>xml:.*</exclude>
-                  </excludes>
-                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -1816,6 +1810,9 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
           <version>0.18.19</version>
           <configuration>
             <license>file:${basedir}/LICENSE.txt</license>
+            <excludes>
+              <exclude>xml:.*</exclude>
+            </excludes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
For https://github.com/artipie/ppom/issues/53:

Bug: `jcabi-parent` overrides `license` file location `qulice` plugin property defined in children `pluginManagement` configuration in `qulice` profile. It should be defined in parent `pluginManagement` to support configuration.

Solution: move qulice plugin configuration from plugin definition in qulice profile to pluginManagement section to avoid overriding license configuration options.