### PR TITLE
(#132) Remove `-Werror` from javac args

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1689,10 +1689,10 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
             <target>${maven.compiler.target}</target>
             <optimize>true</optimize>
             <showWarnings>true</showWarnings>
+            <failOnWarning>true</failOnWarning>
             <showDeprecation>true</showDeprecation>
             <compilerArgs>
               <arg>-Xlint</arg>
-              <arg>-Werror</arg>
               <arg>-Xlint:-path</arg>
               <!-- @see https://stackoverflow.com/questions/44675503/why-safevarargs-doesnt-suppress-the-warning -->
               <arg>-Xlint:-varargs</arg>


### PR DESCRIPTION
- Avoid using `-Werror`
- Use plugin option instead