### PR TITLE
maven-compiler-plugin version downgrade from 3.9.0 to 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1689,7 +1689,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.9.0</version>
+          <version>3.8.1</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <target>${maven.compiler.target}</target>


### PR DESCRIPTION
Related to issue: https://github.com/objectionary/eo-hamcrest/issues/87

The new version of this plugin (3.10.1) did not solve this problem. Therefore, it is better to return to the old one.