### PR TITLE
Downgraded the artifact "jakarta.ws.rs:jakarta.ws.rs-api" for compatibility with Java 11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1338,7 +1338,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
         <!-- JSR-311 JAX-RS API -->
         <groupId>jakarta.ws.rs</groupId>
         <artifactId>jakarta.ws.rs-api</artifactId>
-        <version>4.0.0</version>
+        <version>3.1.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
@yegor256 
The artifact "jakarta.ws.rs:jakarta.ws.rs-api:4.0.0" is not compatible with JDK 11, only with 17 and later.
[Jakarta EE 11](https://jakarta.ee/specifications/platform/11/jakarta-platform-spec-11.0-m4#container-requirements):
`This specification requires that containers support execution in a Java™ runtime environment, as defined by the Java Platform, Standard Edition specification, v17 or later (Java SE 17 or later).`
I rolled back the version of this artifact to 3.1.0.
If this is not needed, please close this PR.