### PR TITLE
#626: Remove deprecated flag optimize in maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1705,7 +1705,6 @@
           <configuration>
             <source>${maven.compiler.source}</source>
             <target>${maven.compiler.target}</target>
-            <optimize>true</optimize>
             <showWarnings>true</showWarnings>
             <failOnWarning>true</failOnWarning>
             <showDeprecation>true</showDeprecation>


### PR DESCRIPTION
Remove deprecated flag `optimize` in `maven-compiler-plugin`.