### PR TITLE
#610: Remove license param from qulice-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1870,7 +1870,6 @@
           <artifactId>qulice-maven-plugin</artifactId>
           <version>0.24.0</version>
           <configuration>
-            <license>file:${basedir}/LICENSE.txt</license>
             <excludes>
               <exclude>xml:.*</exclude>
             </excludes>


### PR DESCRIPTION
@yegor256 Remove `<license>` tag from `qulice-maven-plugin` to avoid warning message.