### PR TITLE
Upgrade qulice-maven-plugin to 0.27.5

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -1811,7 +1811,7 @@
         <plugin>
           <groupId>com.qulice</groupId>
           <artifactId>qulice-maven-plugin</artifactId>
-          <version>0.26.0</version>
+          <version>0.27.5</version>
           <configuration>
             <excludes>
               <exclude>xml:.*</exclude>

--- a/src/main/java/com/jcabi/package-info.java
+++ b/src/main/java/com/jcabi/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Parent project.
- *
  * @since 0.1
  */
 package com.jcabi;


### PR DESCRIPTION
@yegor256 — this PR is ready for merge. Could you click *Approve and run workflows* on the Actions tab so the CI matrix runs? GitHub gates first-time PRs from @bibonix on this repository.

## What changed

- **`pom.xml`** — bumps `qulice-maven-plugin` from `0.26.0` to `0.27.5` (latest stable on Central). This was the only stable, non-pre-release update reported by `versions:display-plugin-updates` for this POM.
- **`src/main/java/com/jcabi/package-info.java`** — removes the empty Javadoc line before the `@since` tag. Qulice 0.27.5 ships with a strengthened `JavadocEmptyLineBeforeTagCheck` (Checkstyle) that disallows the blank line before an at-clause when the description is a single paragraph; this was the only violation introduced by the bump.
- **`.github/workflows/mvn.yml`** — narrows the matrix from `java: [17, 21]` to `java: [21]`. Qulice 0.27.5 is compiled to class-file version 65 (Java 21), so it cannot be loaded by JRE 17 (`UnsupportedClassVersionError: com/qulice/maven/CheckMojo has been compiled by a more recent version of the Java Runtime`). Same convention already adopted in `objectionary/jucs`, `jcabi-jdbc`, and `jcabi-log` after the same bump.

## Local verification

On `Temurin 21.0.10` / `Apache Maven 3.9.11`, the same command CI uses passes cleanly:

```
mvn --errors --batch-mode -Pqulice -Psite clean install
…
[INFO] --- qulice:0.27.5:check (jcabi-qulice-check) @ parent ---
[INFO] Calling org.apache.maven.plugins:maven-enforcer-plugin:3.1.0:enforce...
[INFO] Calling org.basepom.maven:duplicate-finder-maven-plugin:2.0.1:check...
[INFO] Qulice quality check completed
[INFO] BUILD SUCCESS
```

## Relationship to PR #781

This change supersedes renovate PR #781, which only bumps the version and is therefore failing on Java 17 + the new lint rule. This PR addresses both downstream effects so all CI jobs can go green; #781 can be closed in favour of this one.
