### PR TITLE
Read javadoc source level from maven.compiler.source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
               <failOnError>true</failOnError>
-              <source>8</source>
+              <source>${maven.compiler.source}</source>
               <quiet>true</quiet>
               <links>
                 <link>https://docs.oracle.com/en/java/javase/14/docs/api/</link>
@@ -1726,7 +1726,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.12.0</version>
           <configuration>
-            <source>8</source>
+            <source>${maven.compiler.source}</source>
             <tags>
               <tag>
                 <name>todo</name>


### PR DESCRIPTION
Both places where `maven-javadoc-plugin` is configured hardcoded
`<source>8</source>` — the `pluginManagement` entry and the reporting
entry in the `site` profile. Both now read `${maven.compiler.source}`,
the same property `maven-compiler-plugin` already uses.

The old setup broke any child that compiles above Java 8. The code
compiled fine and then `javadoc:jar` blew up on syntax the pinned
`-source 8` front end refuses, such as private interface methods.
That is what killed the `0.62.0` release of `objectionary/eo`.

I checked the effective POM: with the default `1.8` nothing moves,
and a child overriding `maven.compiler.source` now shifts the
compiler and javadoc together instead of only one of them.

Closes #833