### PR TITLE
Drop the doclint-disabling profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,6 @@
     Options for maven-javadoc-plugin. Doclint stays on, since the custom
     Qulice tags are registered in maven-javadoc-plugin below and javadoc
     accepts them. Override this property to loosen the checks.
-    ~ @todo #81:30m/DEV Turn on failOnWarnings in maven-javadoc-plugin.
-    ~  Doclint reports a forgotten @param or an undocumented class as a
-    ~  warning, and the build stays green. The five biggest jcabi
-    ~  projects together produce fourteen such warnings, so the cleanup
-    ~  is small, but it belongs to a separate change.
     -->
     <javadoc.opts>-Xdoclint:all</javadoc.opts>
     <skipITs/>
@@ -342,6 +337,7 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
               <failOnError>true</failOnError>
+              <failOnWarnings>true</failOnWarnings>
               <source>${maven.compiler.source}</source>
               <quiet>true</quiet>
               <links>
@@ -1729,6 +1725,7 @@
           <version>3.12.0</version>
           <configuration>
             <source>${maven.compiler.source}</source>
+            <failOnWarnings>true</failOnWarnings>
             <tags>
               <tag>
                 <name>todo</name>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,17 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <github.repo>jcabi/parent</github.repo>
+    <!--
+    Options for maven-javadoc-plugin. Doclint stays on, since the custom
+    Qulice tags are registered in maven-javadoc-plugin below and javadoc
+    accepts them. Override this property to loosen the checks.
+    ~ @todo #81:30m/DEV Turn on failOnWarnings in maven-javadoc-plugin.
+    ~  Doclint reports a forgotten @param or an undocumented class as a
+    ~  warning, and the build stays green. The five biggest jcabi
+    ~  projects together produce fourteen such warnings, so the cleanup
+    ~  is small, but it belongs to a separate change.
+    -->
+    <javadoc.opts>-Xdoclint:all</javadoc.opts>
     <skipITs/>
   </properties>
   <repositories>
@@ -219,15 +230,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jcabi-doclint-java8-disable</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <properties>
-        <javadoc.opts>-Xdoclint:none</javadoc.opts>
-      </properties>
     </profile>
     <profile>
       <!--


### PR DESCRIPTION
The `jcabi-doclint-java8-disable` profile is gone. `javadoc.opts` is now
an ordinary property in the top-level `<properties>` block, set to
`-Xdoclint:all`, and `maven-javadoc-plugin` gets `failOnWarnings` in
both the packaging entry and the site report.

The profile activated on `[1.8,)`, which means it has been on for every
build anyone has run in the last decade — the name says "java8" but
nothing about it was conditional. So javadoc has been silent about
missing `@param` tags, broken `{@link}` references and unescaped `<`
in every project that inherits from here. `failOnWarnings` matters
because doclint reports a forgotten `@param` and an undocumented class
as warnings, and without it the build would still go green.

About the conflict with the Qulice tags that held this back: it is
already solved. The `<tags>` block of `maven-javadoc-plugin` registers
`@todo` and `@checkstyle` in both `pluginManagement` and the `site`
reporting section, so javadoc accepts them and doclint says nothing.
I checked a probe class carrying both tags — it builds its
`-javadoc.jar` cleanly. On real code I ran javadoc over jcabi-log,
jcabi-xml, jcabi-http, jcabi-github and jcabi-aspects: 287
`@todo`/`@checkstyle` tags between them, not one of which doclint
objects to.

Expect some cleanup downstream, though not much: those five projects
produce 9 errors and 14 warnings in total, and every one is a real
defect — `@link` written as a block tag, an `<a href=` missing its
opening quote, a class with no comment on its implicit constructor.
A project that is not ready can still set
`<javadoc.opts>-Xdoclint:none</javadoc.opts>` while it catches up,
which the profile form did not really allow.

Closes #81