### PR TITLE
Drop maven-plugin-plugin from site reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,10 +401,6 @@
             <artifactId>maven-plugin-report-plugin</artifactId>
             <version>3.15.2</version>
           </plugin>
-          <plugin>
-            <artifactId>maven-plugin-plugin</artifactId>
-            <version>3.15.2</version>
-          </plugin>
         </plugins>
       </reporting>
     </profile>


### PR DESCRIPTION
This removes the `maven-plugin-plugin` entry from the `<reporting>` section of the `site` profile. The neighbouring `maven-plugin-report-plugin` entry stays untouched.

That plugin lost its report goals in 3.7.0, when `report` and `report-no-fork` moved out into `maven-plugin-report-plugin`. Since then, any project with `maven-plugin` packaging that runs `mvn site -Psite` gets a warning saying the plugin has no report goals and should be dropped from the POM — and a child cannot remove an inherited report plugin, so the warning sticks around forever.

Nothing is lost: `plugin-info.html` and the per-mojo pages are produced by `maven-plugin-report-plugin`, which is still declared right above.

Closes #845